### PR TITLE
fix memory leak

### DIFF
--- a/prompt.c
+++ b/prompt.c
@@ -1132,6 +1132,7 @@ void luap_enter(lua_State *L)
         int status;
 
         if (*line == '\0') {
+            free(line);
             continue;
         }
 


### PR DESCRIPTION
How to reproduce this memory leak in previous versions:

```
$ ./luap
>
>
>
```

(just press Enter)
