### PR TITLE
add dostring function 

### DIFF
--- a/prompt.h
+++ b/prompt.h
@@ -39,6 +39,11 @@ void luap_gethistory(lua_State *L, const char **file);
 void luap_getcolor(lua_State *L, int *enabled);
 void luap_getname(lua_State *L, const char **name);
 
+
+/* Execute a string as if it was typed into the prompt.
+ * Returns 1 if the string is incomplete, and 0 otherwise. */
+int luap_dostring(lua_State *L, const char* line, size_t sz);
+
 void luap_enter(lua_State *L);
 char *luap_describe (lua_State *L, int index);
 int luap_call (lua_State *L, int n);


### PR DESCRIPTION
In the program I'm writing I needed to add the capability to execute a script before entering interactive mode. I wanted the execution of the script to report errors in the same way as luaprompt did, so I wanted to execute the script using the luaprompt internal functions. 

So I've added a luap_dostring function, moved the execution code from the REPL loop to it, and called it from the REPL loop. 

So now  I'm able to execute my startup script before entering the interactive session by calling
```
l = asprintf(&buf, "dofile(\"%s\")", script_name);
luap_dostring(L, buf, l);
```

and I get the pretty printed errors if the script contains errors.